### PR TITLE
Ensure Ruby available for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN if [ "$UID" -ne "" ] ; then \
       useradd user -d /app -u $UID; \
     fi
 
-RUN apt-get update -qq && apt-get install -y git
+RUN apt-get update -qq \
+    && apt-get install -y git ruby-full \
+    && gem install bundler
 COPY . .
 RUN bundle install


### PR DESCRIPTION
## Summary
- install ruby-full and bundler in Docker image so `gem` commands are available during build

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rspec` *(fails: command not found: rspec)*


------
https://chatgpt.com/codex/tasks/task_e_6892cd4415888322afcc05d37d719d6e