### PR TITLE
Set default morphology segmentation parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ development:
     key: "<%= ENV.fetch("COELACANTH_SCREENSHOT_ONE_API_KEY", "your_screenshot_one_api_key_here") %>"
   youtube:
     api_key: "<%= ENV.fetch("COELACANTH_YOUTUBE_API_KEY", "") %>"
+  morphology:
+    latin_joiners:
+      - ","
+    japanese_hiragana_suffixes:
+      - "ら"
+      - "の"
+      - "え"
+    japanese_category_breaks:
+      - "katakana_to_kanji"
 ```
 
 - **Ferrum client** – Requires a running Chrome instance that exposes the DevTools protocol via WebSocket. Configure the URL,
@@ -155,6 +164,19 @@ development:
   thumbnail for downstream processing.
 - Configuration is environment-aware: set `RAILS_ENV`/`RACK_ENV` or use Rails' built-in environment handling when the gem is
   used inside a Rails project.
+
+#### Morphological analyzer tuning
+
+The terms returned in `body_morphemes` can be tuned per deployment by configuring the optional `morphology` section:
+
+- `morphology.latin_joiners` — An array of characters that should be treated as connectors between Latin tokens. The default
+  value includes a comma so numbers such as `7,000` stay intact instead of being split into separate terms.
+- `morphology.japanese_hiragana_suffixes` — A whitelist of Hiragana tokens that are allowed to extend Kanji sequences. By
+  default we keep common nominal suffixes such as `ら`, `の`, and the trailing `え` in `訴え` while preventing particles like `に`
+  from merging with the preceding noun. Provide your own list or set the value to `null`/`~` to allow any Hiragana suffix.
+- `morphology.japanese_category_breaks` — An array of transitions (e.g., `katakana_to_kanji`) that should stop Japanese token
+  sequences. This is useful when you want Katakana loanwords such as `タワマン` to stand alone instead of being merged with the
+  Kanji terms that follow them.
 
 Representative images are downloaded into a temporary directory using the built-in HTTP client. The extractor returns both the
 resolved URL and the local file path via `extraction[:eyecatch_image]`. Remember to move or delete the file once you have

--- a/config/coelacanth.yml
+++ b/config/coelacanth.yml
@@ -13,6 +13,25 @@ development: &development
     key: "<%= ENV.fetch("COELACANTH_SCREENSHOT_ONE_API_KEY", "your_screenshot_one_api_key_here") %>"
   youtube:
     api_key: "<%= ENV.fetch("COELACANTH_YOUTUBE_API_KEY", "") %>"
+  morphology:
+    # Example configuration:
+    # latin_joiners:
+    #   - "'"
+    #   - "-"
+    # japanese_hiragana_suffixes:
+    #   - "さん"
+    #   - "ちゃん"
+    # japanese_category_breaks:
+    #   - "kanji_to_katakana"
+    #   - "katakana_to_kanji"
+    latin_joiners:
+      - ","
+    japanese_hiragana_suffixes:
+      - "ら"
+      - "の"
+      - "え"
+    japanese_category_breaks:
+      - "katakana_to_kanji"
 test:
   <<: *development
 production:

--- a/lib/coelacanth/extractor.rb
+++ b/lib/coelacanth/extractor.rb
@@ -56,7 +56,7 @@ module Coelacanth
       node = result.node
       body_markdown = MarkdownRenderer.render(node)
       body_markdown_list = body_markdown.to_s.split(/\n{2,}/).map { |segment| segment.strip }.reject(&:empty?)
-      body_morphemes = MorphologicalAnalyzer.new.call(
+      body_morphemes = MorphologicalAnalyzer.new(config: Coelacanth.config).call(
         node: node,
         title: result.title,
         markdown: body_markdown

--- a/lib/coelacanth/extractor/morphological_analyzer.rb
+++ b/lib/coelacanth/extractor/morphological_analyzer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "set"
 require "strscan"
 
 module Coelacanth
@@ -50,7 +51,18 @@ module Coelacanth
         accent: 1.1
       }.freeze
 
+      CATEGORY_ALIASES = {
+        "kanji" => :kanji,
+        "hiragana" => :hiragana,
+        "katakana" => :katakana,
+        "latin" => :latin
+      }.freeze
+
       Term = Struct.new(:key, :token, :components, :language, keyword_init: true)
+
+      def initialize(config: Coelacanth.config)
+        @config = config
+      end
 
       def call(node:, title:, markdown:)
         stats = Hash.new do |hash, key|
@@ -206,7 +218,8 @@ module Coelacanth
           when :latin
             sequences, index = consume_latin_sequences(tokens, index)
             sequences.each do |sequence|
-              normalized = sequence.map { |component| component[:normalized] }.join(" ")
+              joined = join_latin_sequence(sequence)
+              normalized = joined[:normalized]
               components = sequence.length
 
               next unless valid_english_term?(normalized)
@@ -245,7 +258,7 @@ module Coelacanth
           break unless pointer < tokens.length
 
           next_token = tokens[pointer]
-          break unless next_token[:category] == :latin && whitespace_gap?(next_token[:gap])
+          break unless next_token[:category] == :latin && joinable_gap?(next_token[:gap], :latin)
         end
 
         sequences = split_latin_run(run)
@@ -294,8 +307,10 @@ module Coelacanth
       end
 
       def japanese_sequence_continues?(current, following)
+        return false if japanese_category_break?(current, following)
+
         return false unless japanese_noun_token?(following) ||
-          (following[:category] == :latin && following[:gap].empty?) ||
+          (following[:category] == :latin && joinable_gap?(following[:gap], :latin)) ||
           hiragana_suffix?(current, following)
 
         gap = following[:gap]
@@ -309,11 +324,38 @@ module Coelacanth
       end
 
       def hiragana_suffix?(current, following)
-        current[:category] == :kanji && following[:category] == :hiragana && following[:gap].empty?
+        return false unless current[:category] == :kanji
+        return false unless following[:category] == :hiragana
+        return false unless following[:gap].empty?
+
+        suffixes = configured_hiragana_suffixes
+        return true if suffixes.nil?
+
+        suffixes.include?(following[:raw])
       end
 
       def whitespace_gap?(gap)
         gap.strip.empty?
+      end
+
+      def joinable_gap?(gap, category)
+        return true if whitespace_gap?(gap)
+
+        case category
+        when :latin
+          connector_gap?(gap)
+        else
+          false
+        end
+      end
+
+      def connector_gap?(gap)
+        return false if gap.nil?
+
+        stripped = gap.delete("\s")
+        return false if stripped.empty?
+
+        stripped.chars.all? { |char| latin_joiners.include?(char) }
       end
 
       def normalize_token(token, category)
@@ -428,6 +470,82 @@ module Coelacanth
         end
 
         texts.join(" ")
+      end
+
+      def join_latin_sequence(sequence)
+        token_builder = String.new
+        normalized_builder = String.new
+
+        sequence.each_with_index do |component, index|
+          if index.zero?
+            token_builder << component[:raw]
+            normalized_builder << component[:normalized]
+            next
+          end
+
+          gap = component[:gap]
+
+          if connector_gap?(gap)
+            token_builder << gap
+            normalized_builder << gap_connector_representation(gap)
+          else
+            token_builder << " "
+            normalized_builder << " "
+          end
+
+          token_builder << component[:raw]
+          normalized_builder << component[:normalized]
+        end
+
+        { token: token_builder, normalized: normalized_builder }
+      end
+
+      def gap_connector_representation(gap)
+        stripped = gap.delete("\s")
+        return gap if stripped.empty?
+
+        stripped + (gap.match?(/\s+$/) ? " " : "")
+      end
+
+      def latin_joiners
+        @latin_joiners ||= Array(config_read("morphology.latin_joiners")).map(&:to_s)
+      end
+
+      def configured_hiragana_suffixes
+        @configured_hiragana_suffixes ||= begin
+          suffixes = config_read("morphology.japanese_hiragana_suffixes")
+          suffixes&.map(&:to_s)
+        end
+      end
+
+      def configured_japanese_category_breaks
+        @configured_japanese_category_breaks ||= begin
+          entries = Array(config_read("morphology.japanese_category_breaks"))
+          entries.each_with_object(Set.new) do |entry, set|
+            next unless entry
+
+            from, to = entry.to_s.split(/_to_/, 2)
+            from_category = CATEGORY_ALIASES[from]
+            to_category = CATEGORY_ALIASES[to]
+
+            set << [from_category, to_category] if from_category && to_category
+          end
+        end
+      end
+
+      def japanese_category_break?(current, following)
+        breaks = configured_japanese_category_breaks
+        return false if breaks.empty?
+
+        breaks.include?([current[:category], following[:category]])
+      end
+
+      def config_read(key)
+        return nil unless @config
+
+        @config.read(key)
+      rescue NoMethodError
+        nil
       end
     end
   end

--- a/spec/lib/coelacanth/extractor/extractor_spec.rb
+++ b/spec/lib/coelacanth/extractor/extractor_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe Coelacanth::Extractor do
     let(:config_double) { instance_double(Coelacanth::Configure) }
 
     before do
+      allow(config_double).to receive(:read).and_return(nil)
       allow(Coelacanth).to receive(:config).and_return(config_double)
     end
 

--- a/spec/lib/coelacanth/extractor/morphological_analyzer_spec.rb
+++ b/spec/lib/coelacanth/extractor/morphological_analyzer_spec.rb
@@ -3,7 +3,9 @@
 require "spec_helper"
 
 RSpec.describe Coelacanth::Extractor::MorphologicalAnalyzer do
-  subject(:analyzer) { described_class.new }
+  subject(:analyzer) { described_class.new(config: config) }
+
+  let(:config) { instance_double(Coelacanth::Configure, read: nil) }
 
   it "extracts frequency-sorted morphemes from mixed text" do
     markdown = <<~MARKDOWN
@@ -25,5 +27,54 @@ RSpec.describe Coelacanth::Extractor::MorphologicalAnalyzer do
 
   it "returns an empty array when the markdown is blank" do
     expect(analyzer.call(node: nil, title: nil, markdown: "")).to eq([])
+  end
+
+  context "with default configuration" do
+    let(:config) { Coelacanth.config }
+
+    it "keeps numeric commas and splits mixed Japanese sequences" do
+      markdown = <<~MARKDOWN
+        7,000 Cameras in Japan Compromised, Security Firm Finds
+        京都にタワマン住民ら違法性訴え
+      MARKDOWN
+
+      tokens = analyzer.call(node: nil, title: nil, markdown: markdown).map { |entry| entry[:token] }
+
+      expect(tokens).to include("7,000 camera")
+      expect(tokens).to include("京都", "タワマン", "住民ら違法性訴え")
+      expect(tokens).not_to include("京都にタワマン住民ら違法性訴え")
+    end
+  end
+
+  context "with configurable segmentation" do
+    let(:config) { instance_double(Coelacanth::Configure) }
+
+    before do
+      allow(config).to receive(:read) do |key|
+        {
+          "morphology.latin_joiners" => [","],
+          "morphology.japanese_hiragana_suffixes" => %w[ら の え],
+          "morphology.japanese_category_breaks" => ["katakana_to_kanji"]
+        }[key]
+      end
+    end
+
+    it "honours latin joiners when assembling tokens" do
+      markdown = "7,000 Cameras in Japan Compromised, Security Firm Finds"
+
+      tokens = analyzer.call(node: nil, title: nil, markdown: markdown).map { |entry| entry[:token] }
+
+      expect(tokens).to include("7,000 camera")
+      expect(tokens).to include(a_string_including("security firm"))
+    end
+
+    it "restricts japanese sequences to the configured hiragana suffixes" do
+      markdown = "京都にタワマン住民ら違法性訴え"
+
+      tokens = analyzer.call(node: nil, title: nil, markdown: markdown).map { |entry| entry[:token] }
+
+      expect(tokens).to include("京都", "タワマン", "住民ら違法性訴え")
+      expect(tokens).not_to include("京都にタワマン住民ら違法性訴え")
+    end
   end
 end


### PR DESCRIPTION
## Summary
- set default morphology defaults to keep numeric commas, restrict hiragana suffix joins, and break katakana-to-kanji sequences
- document the new defaults and guidance for overriding them in the README
- add specs confirming the default configuration yields the expected morphemes

## Testing
- bundle install
- bundle exec rspec

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f22a10d908322be129536fd8bb626)