### PR TITLE
Add plain-text morphological analysis helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ result[:extraction] # => article metadata and body markdown
 result[:dom]        # => Oga DOM representation for downstream processing
 result[:screenshot] # => PNG screenshot as a binary string
 result[:response]   # => HTTP status, headers, and final URL
+
+# Plain-text morphology
+
+You can run the morphological analyzer without fetching a page by passing plain
+text:
+
+```ruby
+Coelacanth.morphological_analysis("これはテストです。 Testing morphology twice.")
+# => [
+#      { token: "testing morphology twice", score: 1.23, count: 2 },
+#      { token: "テスト", score: 1.02, count: 1 },
+#      ...
+#    ]
+```
 ```
 
 The returned hash includes:

--- a/lib/coelacanth.rb
+++ b/lib/coelacanth.rb
@@ -50,4 +50,10 @@ module Coelacanth
   def self.config
     @config ||= Configure.new
   end
+
+  def self.morphological_analysis(text, title: nil)
+    Extractor::MorphologicalAnalyzer
+      .new(config: config)
+      .call_text(text, title: title)
+  end
 end

--- a/lib/coelacanth/extractor/morphological_analyzer.rb
+++ b/lib/coelacanth/extractor/morphological_analyzer.rb
@@ -64,6 +64,10 @@ module Coelacanth
         @config = config
       end
 
+      def call_text(text, title: nil)
+        call(node: nil, title: title, markdown: text)
+      end
+
       def call(node:, title:, markdown:)
         stats = Hash.new do |hash, key|
           hash[key] = {

--- a/spec/lib/coelacanth/extractor/morphological_analyzer_spec.rb
+++ b/spec/lib/coelacanth/extractor/morphological_analyzer_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Coelacanth::Extractor::MorphologicalAnalyzer do
     expect(scores).to eq(scores.sort.reverse)
   end
 
+  it "supports direct text input" do
+    result = analyzer.call_text("これはテストです。これはサンプルです。 Testing morphology twice.")
+
+    expect(result).to all(include(:token, :score, :count))
+    expect(result.map { |entry| entry[:token] }).to include("テスト", "サンプル", "testing morphology twice")
+  end
+
   it "returns an empty array when the markdown is blank" do
     expect(analyzer.call(node: nil, title: nil, markdown: "")).to eq([])
   end

--- a/spec/lib/coelacanth_spec.rb
+++ b/spec/lib/coelacanth_spec.rb
@@ -153,4 +153,18 @@ RSpec.describe Coelacanth do
       expect(Coelacanth.config).to be(config_instance)
     end
   end
+
+  describe "#morphological_analysis" do
+    let(:config) { instance_double(Coelacanth::Configure) }
+    let(:analyzer) { instance_double(Coelacanth::Extractor::MorphologicalAnalyzer) }
+
+    it "delegates to the morphological analyzer" do
+      allow(Coelacanth).to receive(:config).and_return(config)
+      allow(Coelacanth::Extractor::MorphologicalAnalyzer)
+        .to receive(:new).with(config: config).and_return(analyzer)
+      allow(analyzer).to receive(:call_text).with("入力テキスト", title: "タイトル").and_return([:morphemes])
+
+      expect(Coelacanth.morphological_analysis("入力テキスト", title: "タイトル")).to eq([:morphemes])
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- add a convenience wrapper on MorphologicalAnalyzer for plain-text input
- expose Coelacanth.morphological_analysis and document usage in the README
- cover the new entry points with specs alongside existing analyzer coverage

## Testing
- bundle exec rspec


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f325b1fcc83228bf7b54ee7402df9)