### PR TITLE
Add Gotenberg screenshot client

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ YouTube, so non-video pages continue to behave as before.
 When using Docker Compose, you can create a `.env` file or export the variables in your environment so the `app` service picks
 them up automatically.
 
+Docker Compose also starts a `gotenberg` service and passes `COELACANTH_GOTENBERG_URL` to the `app` service by default.
+To try that path locally, set `client: "gotenberg"` in `config/coelacanth.yml` or export the equivalent environment-specific
+configuration before running the app container.
+
 If you are working inside Docker, make sure the `UID` environment variable matches your host user by exporting it in your shell
 startup file:
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Runtime configuration is stored in `config/coelacanth.yml`. Environments inherit
 
 ```yaml
 development:
-  client: "ferrum" # Options: "ferrum", "screenshot_one"
+  client: "ferrum" # Options: "ferrum", "screenshot_one", "gotenberg"
   remote_client:
     ws_url: "ws://chrome:3000/chrome"
     timeout: 10
@@ -155,6 +155,13 @@ development:
       User-Agent: "<%= ENV.fetch("COELACANTH_REMOTE_CLIENT_USER_AGENT", "Coelacanth Chrome Extension") %>"
   screenshot_one:
     key: "<%= ENV.fetch("COELACANTH_SCREENSHOT_ONE_API_KEY", "your_screenshot_one_api_key_here") %>"
+  gotenberg:
+    url: "<%= ENV.fetch("COELACANTH_GOTENBERG_URL", "http://gotenberg:3000") %>"
+    open_timeout: 5
+    read_timeout: 30
+    wait_delay: "<%= ENV.fetch("COELACANTH_GOTENBERG_WAIT_DELAY", "") %>"
+    user_agent: "<%= ENV.fetch("COELACANTH_GOTENBERG_USER_AGENT", "") %>"
+    extra_http_headers:
   youtube:
     api_key: "<%= ENV.fetch("COELACANTH_YOUTUBE_API_KEY", "") %>"
   morphology:
@@ -171,6 +178,9 @@ development:
 - **Ferrum client** – Requires a running Chrome instance that exposes the DevTools protocol via WebSocket. Configure the URL,
   timeout, the network idle timeout, and any headers to inject.
 - **ScreenshotOne client** – Supply an API key to offload screenshot capture to [ScreenshotOne](https://screenshotone.com/).
+- **Gotenberg client** – Set `client: "gotenberg"` to capture screenshots through Gotenberg's Chromium URL screenshot
+  endpoint. Configure `gotenberg.url`, request timeouts, an optional `wait_delay`, an optional screenshot `user_agent`,
+  and optional `extra_http_headers`.
 - **Eyecatch image extraction** – Representative images are discovered automatically by checking Open Graph/Twitter metadata,
   Schema.org JSON-LD payloads, and high-signal `<img>` elements (hero/cover images, large dimensions, etc.). No manual XPath
   maintenance is required.
@@ -207,6 +217,9 @@ export COELACANTH_REMOTE_CLIENT_AUTHORIZATION="Bearer <token>"
 
 export COELACANTH_REMOTE_CLIENT_USER_AGENT="Coelacanth Chrome Extension"
 export COELACANTH_SCREENSHOT_ONE_API_KEY="your_screenshot_one_api_key_here"
+export COELACANTH_GOTENBERG_URL="http://gotenberg:3000"
+export COELACANTH_GOTENBERG_WAIT_DELAY="2s"
+export COELACANTH_GOTENBERG_USER_AGENT="Coelacanth Chrome Extension"
 export COELACANTH_YOUTUBE_API_KEY="your_youtube_data_api_key"
 ```
 

--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,9 @@ services:
       - COELACANTH_REMOTE_CLIENT_AUTHORIZATION=${COELACANTH_REMOTE_CLIENT_AUTHORIZATION:-}
       - COELACANTH_REMOTE_CLIENT_USER_AGENT=${COELACANTH_REMOTE_CLIENT_USER_AGENT:-}
       - COELACANTH_SCREENSHOT_ONE_API_KEY=${COELACANTH_SCREENSHOT_ONE_API_KEY:-}
+      - COELACANTH_GOTENBERG_URL=${COELACANTH_GOTENBERG_URL:-http://gotenberg:3000}
+      - COELACANTH_GOTENBERG_WAIT_DELAY=${COELACANTH_GOTENBERG_WAIT_DELAY:-}
+      - COELACANTH_GOTENBERG_USER_AGENT=${COELACANTH_GOTENBERG_USER_AGENT:-}
     tty: true
     stdin_open: true
     build:
@@ -17,9 +20,15 @@ services:
       - ./:/app:cached
     working_dir: /app
     command: bash
+    depends_on:
+      - gotenberg
     networks:
       - app-tier
   chrome:
     image: browserless/chrome:latest
+    networks:
+      - app-tier
+  gotenberg:
+    image: gotenberg/gotenberg:8
     networks:
       - app-tier

--- a/config/coelacanth.yml
+++ b/config/coelacanth.yml
@@ -1,5 +1,5 @@
 development: &development
-  client: "ferrum" # Options: "ferrum", "screenshot_one"
+  client: "ferrum" # Options: "ferrum", "screenshot_one", "gotenberg"
   remote_client:
     ws_url: "ws://chrome:3000/chrome"
     timeout: 10 # seconds
@@ -11,6 +11,13 @@ development: &development
       User-Agent: "<%= ENV.fetch("COELACANTH_REMOTE_CLIENT_USER_AGENT", "Coelacanth Chrome Extension") %>"
   screenshot_one:
     key: "<%= ENV.fetch("COELACANTH_SCREENSHOT_ONE_API_KEY", "your_screenshot_one_api_key_here") %>"
+  gotenberg:
+    url: "<%= ENV.fetch("COELACANTH_GOTENBERG_URL", "http://gotenberg:3000") %>"
+    open_timeout: 5
+    read_timeout: 30
+    wait_delay: "<%= ENV.fetch("COELACANTH_GOTENBERG_WAIT_DELAY", "") %>"
+    user_agent: "<%= ENV.fetch("COELACANTH_GOTENBERG_USER_AGENT", "") %>"
+    extra_http_headers:
   youtube:
     api_key: "<%= ENV.fetch("COELACANTH_YOUTUBE_API_KEY", "") %>"
   morphology:

--- a/lib/coelacanth.rb
+++ b/lib/coelacanth.rb
@@ -4,6 +4,7 @@ require "net/http"
 require_relative "coelacanth/configure"
 require_relative "coelacanth/client/base"
 require_relative "coelacanth/client/ferrum"
+require_relative "coelacanth/client/gotenberg"
 require_relative "coelacanth/client/screenshot_one"
 require_relative "coelacanth/dom"
 require_relative "coelacanth/extractor"
@@ -21,7 +22,7 @@ module Coelacanth
   class RobotsDisallowedError < StandardError; end
 
   def self.analyze(url)
-    client_class = config.read("client") == "screenshot_one" ? Client::ScreenshotOne : Client::Ferrum
+    client_class = client_class_for(config.read("client"))
     @client = client_class.new(url)
     regular_url = Redirect.new.resolve_redirect(url)
     response = begin
@@ -45,6 +46,17 @@ module Coelacanth
       extraction: extractor_result,
       response: response_metadata
     }
+  end
+
+  def self.client_class_for(client_name)
+    case client_name
+    when "screenshot_one"
+      Client::ScreenshotOne
+    when "gotenberg"
+      Client::Gotenberg
+    else
+      Client::Ferrum
+    end
   end
 
   def self.config

--- a/lib/coelacanth/client/ferrum.rb
+++ b/lib/coelacanth/client/ferrum.rb
@@ -5,8 +5,8 @@ require "ferrum"
 module Coelacanth::Client
   # Coelacanth::Client
   class Ferrum < Coelacanth::Client::Base
-    def initialize(url)
-      super(url)
+    def initialize(url, config = Coelacanth.config)
+      super(url, config)
       remote_client.goto(url)
     end
 

--- a/lib/coelacanth/client/gotenberg.rb
+++ b/lib/coelacanth/client/gotenberg.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+
+require_relative "../http"
+
+module Coelacanth::Client
+  # Client for capturing screenshots through a Gotenberg Chromium service.
+  class Gotenberg < Coelacanth::Client::Base
+    SCREENSHOT_URL_PATH = "/forms/chromium/screenshot/url"
+
+    def get_response
+      uri = URI.parse(@url)
+      response = Coelacanth::HTTP.get_response(
+        uri,
+        open_timeout: Coelacanth::HTTP::DEFAULT_OPEN_TIMEOUT,
+        read_timeout: Coelacanth::HTTP::DEFAULT_READ_TIMEOUT
+      )
+      @origin_response = response
+      @status_code = response.code.to_i
+
+      return response.body if response.is_a?(Net::HTTPSuccess)
+
+      Coelacanth::HTTP.raise_http_error(uri, response)
+    end
+
+    def get_screenshot
+      response = Net::HTTP.start(
+        endpoint_uri.host,
+        endpoint_uri.port,
+        use_ssl: endpoint_uri.scheme == "https",
+        open_timeout: open_timeout,
+        read_timeout: read_timeout
+      ) do |http|
+        http.request(screenshot_request)
+      end
+
+      return response.body if response.is_a?(Net::HTTPSuccess)
+
+      raise "Failed to fetch screenshot from Gotenberg: #{response.code} #{response.message}"
+    rescue Net::OpenTimeout, Net::ReadTimeout, Timeout::Error => e
+      raise Coelacanth::TimeoutError, "Gotenberg screenshot request timed out: #{e.message}"
+    end
+
+    private
+
+    def screenshot_request
+      request = Net::HTTP::Post.new(endpoint_uri)
+      request.set_form(gotenberg_form_fields, "multipart/form-data")
+      request
+    end
+
+    def gotenberg_form_fields
+      fields = [["url", @url]]
+      wait_delay = @config.read("gotenberg.wait_delay")
+      user_agent = @config.read("gotenberg.user_agent")
+      extra_http_headers = @config.read("gotenberg.extra_http_headers")
+
+      fields << ["waitDelay", wait_delay] if present?(wait_delay)
+      fields << ["userAgent", user_agent] if present?(user_agent)
+      if extra_http_headers && extra_http_headers.any?
+        fields << ["extraHttpHeaders", extra_http_headers.to_json]
+      end
+      fields
+    end
+
+    def endpoint_uri
+      @endpoint_uri ||= URI.join(base_url, SCREENSHOT_URL_PATH)
+    end
+
+    def base_url
+      @config.read("gotenberg.url") || "http://localhost:3000"
+    end
+
+    def open_timeout
+      @config.read("gotenberg.open_timeout") || Coelacanth::HTTP::DEFAULT_OPEN_TIMEOUT
+    end
+
+    def read_timeout
+      @config.read("gotenberg.read_timeout") || 30
+    end
+
+    def present?(value)
+      !value.nil? && value.to_s.strip != ""
+    end
+  end
+end

--- a/lib/coelacanth/version.rb
+++ b/lib/coelacanth/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coelacanth
-  VERSION = "0.5.1"
+  VERSION = "0.6.0"
 end

--- a/spec/compose_spec.rb
+++ b/spec/compose_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+RSpec.describe "compose.yml" do
+  subject(:compose) { YAML.safe_load_file("compose.yml") }
+
+  it "provides Gotenberg to the app service" do
+    app = compose.fetch("services").fetch("app")
+
+    expect(app.fetch("depends_on")).to include("gotenberg")
+    expect(app.fetch("environment")).to include(
+      "COELACANTH_GOTENBERG_URL=${COELACANTH_GOTENBERG_URL:-http://gotenberg:3000}",
+      "COELACANTH_GOTENBERG_WAIT_DELAY=${COELACANTH_GOTENBERG_WAIT_DELAY:-}",
+      "COELACANTH_GOTENBERG_USER_AGENT=${COELACANTH_GOTENBERG_USER_AGENT:-}"
+    )
+  end
+
+  it "defines a Gotenberg service on the application network" do
+    gotenberg = compose.fetch("services").fetch("gotenberg")
+
+    expect(gotenberg.fetch("image")).to eq("gotenberg/gotenberg:8")
+    expect(gotenberg.fetch("networks")).to include("app-tier")
+  end
+end

--- a/spec/lib/coelacanth/client/gotenberg_spec.rb
+++ b/spec/lib/coelacanth/client/gotenberg_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "coelacanth/client/gotenberg"
+require "webmock/rspec"
+
+RSpec.describe Coelacanth::Client::Gotenberg do
+  let(:url) { "http://example.com" }
+  let(:config) do
+    instance_double(Coelacanth::Configure).tap do |cfg|
+      allow(cfg).to receive(:read) do |key|
+        {
+          "client" => "gotenberg",
+          "gotenberg.url" => "http://gotenberg.test:3000",
+          "gotenberg.open_timeout" => 5,
+          "gotenberg.read_timeout" => 30,
+          "gotenberg.wait_delay" => "2s",
+          "gotenberg.user_agent" => "Coelacanth Gotenberg",
+          "gotenberg.extra_http_headers" => { "Authorization" => "Bearer token" }
+        }[key]
+      end
+    end
+  end
+  let(:client) { described_class.new(url, config) }
+
+  describe "#get_response" do
+    it "fetches the page body directly" do
+      stub_request(:get, url).to_return(status: 200, body: "response body")
+
+      expect(client.get_response).to eq("response body")
+      expect(client.instance_variable_get(:@status_code)).to eq(200)
+    end
+
+    it "raises an HTTP error when the page request fails" do
+      stub_request(:get, url).to_return(status: 404, body: "not found")
+
+      expect { client.get_response }.to raise_error(OpenURI::HTTPError)
+      expect(client.instance_variable_get(:@status_code)).to eq(404)
+    end
+  end
+
+  describe "#get_screenshot" do
+    let(:endpoint) { "http://gotenberg.test:3000/forms/chromium/screenshot/url" }
+
+    it "posts a multipart request to Gotenberg and returns the screenshot" do
+      stub_request(:post, endpoint).to_return(status: 200, body: "png data")
+
+      expect(client.get_screenshot).to eq("png data")
+      expect(WebMock).to have_requested(:post, endpoint)
+        .with(headers: { "Content-Type" => /multipart\/form-data/ })
+      expect(client.send(:gotenberg_form_fields)).to include(
+        ["url", url],
+        ["waitDelay", "2s"],
+        ["userAgent", "Coelacanth Gotenberg"],
+        ["extraHttpHeaders", %({"Authorization":"Bearer token"})]
+      )
+    end
+
+    it "raises an error when Gotenberg returns a non-success response" do
+      stub_request(:post, endpoint).to_return(status: 503, body: "unavailable")
+
+      expect { client.get_screenshot }
+        .to raise_error(RuntimeError, /Failed to fetch screenshot from Gotenberg: 503/)
+    end
+
+    it "raises a Coelacanth timeout error when Gotenberg times out" do
+      stub_request(:post, endpoint).to_timeout
+
+      expect { client.get_screenshot }
+        .to raise_error(Coelacanth::TimeoutError, /Gotenberg screenshot request timed out/)
+    end
+  end
+end

--- a/spec/lib/coelacanth_spec.rb
+++ b/spec/lib/coelacanth_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Coelacanth do
     let(:url) { "http://example.com" }
     let(:ferrum_client) { instance_double(Coelacanth::Client::Ferrum) }
     let(:screenshot_one_client) { instance_double(Coelacanth::Client::ScreenshotOne) }
+    let(:gotenberg_client) { instance_double(Coelacanth::Client::Gotenberg) }
     let(:dom) { instance_double(Coelacanth::Dom) }
     let(:extractor) { instance_double(Coelacanth::Extractor) }
     let(:config) { instance_double(Coelacanth::Configure) }
@@ -102,6 +103,16 @@ RSpec.describe Coelacanth do
           allow(config).to receive(:read).with("client").and_return("screenshot_one")
           allow(Coelacanth::Client::ScreenshotOne).to receive(:new).with(url).and_return(screenshot_one_client)
           allow(screenshot_one_client).to receive(:get_screenshot).and_return(screenshot)
+        end
+
+        include_examples "analyze workflow"
+      end
+
+      context "when client is gotenberg" do
+        before do
+          allow(config).to receive(:read).with("client").and_return("gotenberg")
+          allow(Coelacanth::Client::Gotenberg).to receive(:new).with(url).and_return(gotenberg_client)
+          allow(gotenberg_client).to receive(:get_screenshot).and_return(screenshot)
         end
 
         include_examples "analyze workflow"


### PR DESCRIPTION
### Motivation
- Provide an alternative screenshot provider by adding support for Gotenberg's Chromium URL screenshot endpoint so deployments can offload screenshot capture to a Gotenberg service.
- Make client selection extensible so `client: "gotenberg"` can be chosen alongside existing `ferrum` and `screenshot_one` options.

### Description
- Add a new client `Coelacanth::Client::Gotenberg` in `lib/coelacanth/client/gotenberg.rb` that posts a multipart URL screenshot request to `/forms/chromium/screenshot/url` and supports `waitDelay`, `userAgent`, `extraHttpHeaders`, and configurable timeouts.
- Wire the new client into selection logic by adding `client_class_for` to `lib/coelacanth.rb` and `require_relative "coelacanth/client/gotenberg"` so `client: "gotenberg"` instantiates the new client.
- Accept an injected `config` in `Ferrum` initialization signature (`def initialize(url, config = Coelacanth.config)`) to align client constructors.
- Add configuration example keys to `config/coelacanth.yml` and document the new Gotenberg settings and environment variables in `README.md`.
- Add specs: `spec/lib/coelacanth/client/gotenberg_spec.rb` for Gotenberg behavior and update `spec/lib/coelacanth_spec.rb` to include `gotenberg` in the `Coelacanth.analyze` client-selection cases.

### Testing
- Ran `bundle install` successfully to install dependencies.
- Ran `bundle exec rspec` and all specs passed (`68 examples, 0 failures`).
- Adjusted the Gotenberg multipart test to avoid WebMock multipart matching limitations by asserting form fields via the client helper and verifying the request Content-Type header, and those tests now pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fc38e4c4c8322a47c89dc6be0d481)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノーツ

* **新機能**
  * Gotenberg クライアント対応を追加しました。スクリーンショット取得時に、URL、タイムアウト、ユーザーエージェント、追加 HTTP ヘッダーを設定可能です。
* **ドキュメント**
  * 設定ファイルの `client` 選択肢と各パラメータ、環境変数（`COELACANTH_GOTENBERG_*`）、Docker Compose の `gotenberg` 連携手順を追記しました。
* **テスト**
  * Gotenberg クライアントと Compose 設定に関するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->